### PR TITLE
Add grunt-cli to local deps, removing need for global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-Lisk Network Stats
-============
+# Lisk Network Stats
+
 This is a visual interface for tracking lisk network status. It uses WebSockets to receive stats from running nodes and output them through an angular interface. It is the front-end implementation for [lisk-network-reporter](https://github.com/karek314/lisk-network-reporter).
 
 ![Screenshot](https://raw.githubusercontent.com/karek314/lisk-network-stats/master/lisk-network-stats-screenshot.png)
 
-
 ## Installation
+
 <pre>
 wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.32.1/install.sh | bash
 export NVM_DIR="/root/.nvm"
@@ -14,18 +14,20 @@ nvm install 6.2.0
 git clone https://github.com/karek314/lisk-network-stats
 cd lisk-network-stats
 npm install
-npm install -g grunt-cli
 </pre>
 
 ## Build
+
 <pre>
-grunt
+npm run build
 </pre>
 
 ## Configure
+
 Change [secret key](https://github.com/karek314/lisk-network-stats/blob/ebe44d877eada5494fb0ad0cf594a33080a46599/app.js#L7)
 
 ## Run
+
 <pre>
 PORT=3010 npm start
 </pre>
@@ -33,4 +35,5 @@ PORT=3010 npm start
 see the interface at http://localhost:3010
 
 ## Credits
+
 Thanks to [cuberdo](https://github.com/cubedro/) and his [eth-netstats](https://github.com/cubedro/eth-netstats). This software has been created on the top of his work.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "npm": "3.8.9"
   },
   "scripts": {
+    "build": "node node_modules/grunt-cli/bin/grunt",
     "start": "node ./bin/www"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
     "express": "4.14.0",
     "geoip-lite": "1.1.8",
     "grunt": "1.0.1",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-concat": "1.0.1",
     "grunt-contrib-copy": "1.0.0",


### PR DESCRIPTION
This change removes the need to install `grunt-cli` globally.

It also adds a script to package.json which is usable on all development environments (`./node_modules/grunt-cli/bin/grunt` wouldn't work on windows)

Go Lisk! :)